### PR TITLE
Avoid a warning about an unsupported platform.

### DIFF
--- a/dealii/source/base/timer.cc
+++ b/dealii/source/base/timer.cc
@@ -128,7 +128,8 @@ CPUClock::now() noexcept
   getrusage(RUSAGE_SELF, &usage);
   system_cpu_duration = usage.ru_utime.tv_sec + 1.e-6 * usage.ru_utime.tv_usec;
 #else
-  DEAL_II_WARNING("Unsupported platform. Porting not finished.")
+  //DEAL_II_WARNING("Unsupported platform. Porting not finished.")
+  std::abort();
 #endif
   return time_point(
     internal::TimerImplementation::from_seconds<duration>(system_cpu_duration));


### PR DESCRIPTION
This is caused by the fact that for the benchmark, all platform checks are disabled and so we end up in the last of the '#else' branches.